### PR TITLE
Fix missing cache initialization

### DIFF
--- a/src/Google/Http/GoogleAuthMiddleware.php
+++ b/src/Google/Http/GoogleAuthMiddleware.php
@@ -50,6 +50,8 @@ class GoogleAuthMiddleware
      */
     public static function createAuthTokenMiddleware(ServiceCredentials $credentials): AuthTokenMiddleware
     {
+        self::$cache = new MemoryCacheItemPool;
+
         $fetcher = new FetchAuthTokenCache(
             self::createApplicationDefaultCredentials($credentials),
             [],

--- a/src/Google/Http/GoogleAuthMiddleware.php
+++ b/src/Google/Http/GoogleAuthMiddleware.php
@@ -15,7 +15,7 @@ use Psr\Cache\CacheItemPoolInterface;
 
 class GoogleAuthMiddleware
 {
-    private static ?CacheItemPoolInterface $cache;
+    private static ?CacheItemPoolInterface $cache = null;
 
     /** @var string */
     final public const BASE_URI = 'https://walletobjects.googleapis.com/';
@@ -50,12 +50,10 @@ class GoogleAuthMiddleware
      */
     public static function createAuthTokenMiddleware(ServiceCredentials $credentials): AuthTokenMiddleware
     {
-        self::$cache = new MemoryCacheItemPool;
-
         $fetcher = new FetchAuthTokenCache(
             self::createApplicationDefaultCredentials($credentials),
             [],
-            self::$cache,
+            self::getCache(),
         );
 
         if (($client = HttpClientCache::getHttpClient()) === null) {


### PR DESCRIPTION
When setting up the package initially, I ran into a PHP Error while interacting with Google Classes / Objects.

Laravel 8, on PHP 8.1.2

PHP Error:

```
Typed static property Chiiya\Passes\Google\Http\GoogleAuthMiddleware::$cache must not be accessed before initialization
```

Script Line:
```
vendor/chiiya/passes/src/Google/Http/GoogleAuthMiddleware.php:56
```

Fix: insert single line at GoogleAuthMiddleware.php:53

```
/**
 * Obtain an AuthTokenMiddleware for fetching auth credentials.
 *
 * @throws Exception
 */
public static function createAuthTokenMiddleware(ServiceCredentials $credentials): AuthTokenMiddleware
{
    // added this line, to init the cache, before referencing it...
    self::$cache = new MemoryCacheItemPool;
    ...
}
```

This solves the PHP Error.
I'm not sure if this is the best solution, but I will defer to you for better handling...

The invokation can be simplified as below.
Without the fix inside "createAuthTokenMiddleware()", exception occurs when assigning "$client"
With the fix, the authorization works and client can query the API successfully.

```
<?php

namespace App\Http\Controllers;

use Chiiya\Passes\Google\Components\Common\Barcode;
use Chiiya\Passes\Google\Components\Common\DateTime;
use Chiiya\Passes\Google\Components\Common\Image;
use Chiiya\Passes\Google\Components\Common\ImageModuleData;
use Chiiya\Passes\Google\Components\Common\LatLongPoint;
use Chiiya\Passes\Google\Components\Common\LinksModuleData;
use Chiiya\Passes\Google\Components\Common\LocalizedString;
use Chiiya\Passes\Google\Components\Common\TimeInterval;
use Chiiya\Passes\Google\Components\Common\Uri;
use Chiiya\Passes\Google\Enumerators\BarcodeType;
use Chiiya\Passes\Google\Enumerators\MultipleDevicesAndHoldersAllowedStatus;
use Chiiya\Passes\Google\Enumerators\Offer\RedemptionChannel;
use Chiiya\Passes\Google\Enumerators\ReviewStatus;
use Chiiya\Passes\Google\Enumerators\State;
use Chiiya\Passes\Google\Http\GoogleClient;
use Chiiya\Passes\Google\JWT;
use Chiiya\Passes\Google\Passes\LoyaltyClass;
use Chiiya\Passes\Google\Passes\LoyaltyObject;
use Chiiya\Passes\Google\Repositories\LoyaltyClassRepository;
use Chiiya\Passes\Google\ServiceCredentials;


class FooController extends Controller
{

  public function getLoyaltyClass()
  {

      $credentials = ServiceCredentials::parse(env('GP_JSON_PATH'));
      $client = GoogleClient::createAuthenticatedClient($credentials);
      $repository = new LoyaltyClassRepository($client);

      try {
          return $repository->get("123.foobar");
      } catch (\GuzzleHttp\Exception\ClientException $e) {
          return array(
            'status' => false,
            'errors' => array("HTTP Exception. Class not found."),
          );
      }

  }

}

```