### PR TITLE
Add GroupingInfo->groupingId as per docs

### DIFF
--- a/src/Google/Components/EventTicket/GroupingInfo.php
+++ b/src/Google/Components/EventTicket/GroupingInfo.php
@@ -13,4 +13,11 @@ class GroupingInfo extends Component
      * passes with same sort index, the sorting behavior is undefined.
      */
     public ?int $sortIndex;
+
+    /**
+     * Optional
+     * Optional grouping ID for grouping the passes with the same ID visually together. Grouping with different
+     * types of passes is allowed.
+     */
+    public ?string $groupingId;
 }

--- a/src/Google/Passes/BaseObject.php
+++ b/src/Google/Passes/BaseObject.php
@@ -16,6 +16,7 @@ use Chiiya\Passes\Google\Components\Common\LinksModuleData;
 use Chiiya\Passes\Google\Components\Common\Message;
 use Chiiya\Passes\Google\Components\Common\TextModuleData;
 use Chiiya\Passes\Google\Components\Common\TimeInterval;
+use Chiiya\Passes\Google\Components\EventTicket\GroupingInfo;
 use Chiiya\Passes\Google\Enumerators\State;
 use Spatie\DataTransferObject\Attributes\CastWith;
 use Spatie\DataTransferObject\Casters\ArrayCaster;
@@ -81,6 +82,12 @@ abstract class BaseObject extends Component
     #[CastWith(ArrayCaster::class, LatLongPoint::class)]
     #[MaxItems(20)]
     public array $locations = [];
+
+    /**
+     * Optional.
+     * Grouping info for event tickets.
+     */
+    public ?GroupingInfo $groupingInfo;
 
     /**
      * Optional.

--- a/src/Google/Passes/EventTicketObject.php
+++ b/src/Google/Passes/EventTicketObject.php
@@ -7,7 +7,6 @@ use Chiiya\Passes\Google\Components\Common\LocalizedString;
 use Chiiya\Passes\Google\Components\Common\Money;
 use Chiiya\Passes\Google\Components\EventTicket\EventReservationInfo;
 use Chiiya\Passes\Google\Components\EventTicket\EventSeat;
-use Chiiya\Passes\Google\Components\EventTicket\GroupingInfo;
 
 class EventTicketObject extends BaseObject
 {
@@ -57,12 +56,6 @@ class EventTicketObject extends BaseObject
      * The face value of the ticket, matching what would be printed on a physical version of the ticket.
      */
     public ?Money $faceValue;
-
-    /**
-     * Optional.
-     * Grouping info for event tickets.
-     */
-    public ?GroupingInfo $groupingInfo;
 
     /**
      * Optional.

--- a/tests/Google/Fixtures/responses/offer-object.json
+++ b/tests/Google/Fixtures/responses/offer-object.json
@@ -68,5 +68,9 @@
             "date": "2021-01-04T23:59:59+01:00"
         }
     },
+    "groupingInfo": {
+        "sortIndex": 1,
+        "groupingId": "example"
+    },
     "hasUsers": true
 }

--- a/tests/Google/Fixtures/responses/offer-objects.json
+++ b/tests/Google/Fixtures/responses/offer-objects.json
@@ -70,6 +70,10 @@
                     "date": "2021-01-04T23:59:59+01:00"
                 }
             },
+            "groupingInfo": {
+                "sortIndex": 1,
+                "groupingId": "example"
+            },
             "hasUsers": true
         }
     ],


### PR DESCRIPTION
Hi, 

`Chiiya\Passes\Google\Components\EventTicket\GroupingInfo` should contain a property named `$groupingId` as described in docs: https://developers.google.com/wallet/generic/rest/v1/GroupingInfo