### PR TITLE
Remove empty values before encoding

### DIFF
--- a/src/Google/JWT.php
+++ b/src/Google/JWT.php
@@ -177,9 +177,8 @@ class JWT extends Component
      */
     public function sign(): string
     {
-        $payload = array_merge($this->except('key')->toArray(), [
-            'iat' => time(),
-        ]);
+        $payload = $this->removeEmptyValues($this->except('key')->toArray());
+        $payload['iat'] = time();
 
         return Encoder::encode($payload, $this->key, 'RS256');
     }


### PR DESCRIPTION
`jsonSerialize` will never be called after the `Component` has been converted to an array. Fixes #22