### PR TITLE
Add support for the genericType field

### DIFF
--- a/src/Google/Enumerators/Generic/GenericType.php
+++ b/src/Google/Enumerators/Generic/GenericType.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace Chiiya\Passes\Google\Enumerators\Generic;
+
+/**
+ * @see https://developers.google.com/wallet/reference/rest/v1/genericobject#GenericType
+ */
+final class GenericType
+{
+    /** @var string */
+    public const GENERIC_TYPE_UNSPECIFIED = 'GENERIC_TYPE_UNSPECIFIED';
+
+    /** @var string */
+    public const GENERIC_SEASON_PASS = 'GENERIC_SEASON_PASS';
+
+    /** @var string */
+    public const GENERIC_UTILITY_BILLS = 'GENERIC_UTILITY_BILLS';
+
+    /** @var string */
+    public const GENERIC_PARKING_PASS = 'GENERIC_PARKING_PASS';
+
+    /** @var string */
+    public const GENERIC_VOUCHER = 'GENERIC_VOUCHER';
+
+    /** @var string */
+    public const GENERIC_GYM_MEMBERSHIP = 'GENERIC_GYM_MEMBERSHIP';
+
+    /** @var string */
+    public const GENERIC_LIBRARY_MEMBERSHIP = 'GENERIC_LIBRARY_MEMBERSHIP';
+
+    /** @var string */
+    public const GENERIC_RESERVATIONS = 'GENERIC_RESERVATIONS';
+
+    /** @var string */
+    public const GENERIC_AUTO_INSURANCE = 'GENERIC_AUTO_INSURANCE';
+
+    /** @var string */
+    public const GENERIC_HOME_INSURANCE = 'GENERIC_HOME_INSURANCE';
+
+    /** @var string */
+    public const GENERIC_ENTRY_TICKET = 'GENERIC_ENTRY_TICKET';
+
+    /** @var string */
+    public const GENERIC_RECEIPT = 'GENERIC_RECEIPT';
+
+    /** @var string */
+    public const GENERIC_OTHER = 'GENERIC_OTHER';
+
+    public static function values(): array
+    {
+        return [
+            self::GENERIC_TYPE_UNSPECIFIED,
+            self::GENERIC_SEASON_PASS,
+            self::GENERIC_UTILITY_BILLS,
+            self::GENERIC_PARKING_PASS,
+            self::GENERIC_VOUCHER,
+            self::GENERIC_GYM_MEMBERSHIP,
+            self::GENERIC_LIBRARY_MEMBERSHIP,
+            self::GENERIC_RESERVATIONS,
+            self::GENERIC_AUTO_INSURANCE,
+            self::GENERIC_HOME_INSURANCE,
+            self::GENERIC_ENTRY_TICKET,
+            self::GENERIC_RECEIPT,
+            self::GENERIC_OTHER,
+        ];
+    }
+}

--- a/src/Google/Passes/GenericObject.php
+++ b/src/Google/Passes/GenericObject.php
@@ -3,14 +3,37 @@
 namespace Chiiya\Passes\Google\Passes;
 
 use Chiiya\Passes\Common\Validation\HexColor;
+use Chiiya\Passes\Common\Validation\ValueIn;
 use Chiiya\Passes\Google\Components\Common\Image;
 use Chiiya\Passes\Google\Components\Common\LocalizedString;
 use Chiiya\Passes\Google\Components\Generic\Notifications;
+use Chiiya\Passes\Google\Enumerators\Generic\GenericType;
 
 class GenericObject extends AbstractObject
 {
     /** @var string */
     final public const IDENTIFIER = 'genericObject';
+
+    /**
+     * Optional
+     * The type of the generic card.
+     */
+    #[ValueIn([
+        GenericType::GENERIC_TYPE_UNSPECIFIED,
+        GenericType::GENERIC_SEASON_PASS,
+        GenericType::GENERIC_UTILITY_BILLS,
+        GenericType::GENERIC_PARKING_PASS,
+        GenericType::GENERIC_VOUCHER,
+        GenericType::GENERIC_GYM_MEMBERSHIP,
+        GenericType::GENERIC_LIBRARY_MEMBERSHIP,
+        GenericType::GENERIC_RESERVATIONS,
+        GenericType::GENERIC_AUTO_INSURANCE,
+        GenericType::GENERIC_HOME_INSURANCE,
+        GenericType::GENERIC_ENTRY_TICKET,
+        GenericType::GENERIC_RECEIPT,
+        GenericType::GENERIC_OTHER,
+    ])]
+    public ?string $genericType;
 
     /**
      * Required

--- a/tests/Google/Fixtures/Passes.php
+++ b/tests/Google/Fixtures/Passes.php
@@ -20,6 +20,7 @@ use Chiiya\Passes\Google\Components\Generic\Notifications;
 use Chiiya\Passes\Google\Components\Generic\UpcomingNotification;
 use Chiiya\Passes\Google\Enumerators\BarcodeRenderEncoding;
 use Chiiya\Passes\Google\Enumerators\BarcodeType;
+use Chiiya\Passes\Google\Enumerators\Generic\GenericType;
 use Chiiya\Passes\Google\Enumerators\Offer\RedemptionChannel;
 use Chiiya\Passes\Google\Enumerators\ReviewStatus;
 use Chiiya\Passes\Google\Enumerators\State;
@@ -92,6 +93,7 @@ class Passes
     public static function genericObject(): array
     {
         return [
+            'genericType' => GenericType::GENERIC_TYPE_UNSPECIFIED,
             'id' => '1234567891234567891.fb1e9730-a83b-11ed-afa1-0242ac120002',
             'classId' => '1234567891234567891.718bf4ae-a7a5-11ed-afa1-0242ac120002',
             'cardTitle' => LocalizedString::make('en', 'Card title'),

--- a/tests/Google/Fixtures/responses/generic-object.json
+++ b/tests/Google/Fixtures/responses/generic-object.json
@@ -1,4 +1,5 @@
 {
+    "genericType": "GENERIC_TYPE_UNSPECIFIED",
     "cardTitle": {
         "kind": "walletobjects#localizedString",
         "defaultValue": {

--- a/tests/Google/Fixtures/responses/generic-objects.json
+++ b/tests/Google/Fixtures/responses/generic-objects.json
@@ -1,6 +1,7 @@
 {
     "resources": [
         {
+            "genericType": "GENERIC_TYPE_UNSPECIFIED",
             "cardTitle": {
                 "kind": "walletobjects#localizedString",
                 "defaultValue": {


### PR DESCRIPTION
Generic passes have [a `genericType` property](https://developers.google.com/wallet/reference/rest/v1/genericobject#GenericType) that is missing from this implementation. This PR adds it.