### PR TITLE
Use match expressions in mapLegacyValues

### DIFF
--- a/src/Google/Enumerators/BarcodeRenderEncoding.php
+++ b/src/Google/Enumerators/BarcodeRenderEncoding.php
@@ -19,6 +19,9 @@ final class BarcodeRenderEncoding implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace(['UTF_8'], [self::UTF_8], $value);
+        return match ($value) {
+            'UTF_8' => self::UTF_8,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/BarcodeType.php
+++ b/src/Google/Enumerators/BarcodeType.php
@@ -66,38 +66,23 @@ final class BarcodeType implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace([
-            'aztec',
-            'code39',
-            'code128',
-            'codabar',
-            'dataMatrix',
-            'ean8',
-            'ean13',
-            'EAN13',
-            'itf14',
-            'pdf417',
-            'PDF417',
-            'qrCode',
-            'qrcode',
-            'upcA',
-            'textOnly',
-        ], [
-            self::AZTEC,
-            self::CODE_39,
-            self::CODE_128,
-            self::CODABAR,
-            self::DATA_MATRIX,
-            self::EAN_8,
-            self::EAN_13,
-            self::EAN_13,
-            self::ITF_14,
-            self::PDF_417,
-            self::PDF_417,
-            self::QR_CODE,
-            self::QR_CODE,
-            self::UPC_A,
-            self::TEXT_ONLY,
-        ], $value);
+        return match ($value) {
+            'aztec' => self::AZTEC,
+            'code39' => self::CODE_39,
+            'code128' => self::CODE_128,
+            'codabar' => self::CODABAR,
+            'dataMatrix' => self::DATA_MATRIX,
+            'ean8' => self::EAN_8,
+            'ean13' => self::EAN_13,
+            'EAN13' => self::EAN_13,
+            'itf14' => self::ITF_14,
+            'pdf417' => self::PDF_417,
+            'PDF417' => self::PDF_417,
+            'qrCode' => self::QR_CODE,
+            'qrcode' => self::QR_CODE,
+            'upcA' => self::UPC_A,
+            'textOnly' => self::TEXT_ONLY,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/DateFormat.php
+++ b/src/Google/Enumerators/DateFormat.php
@@ -38,12 +38,13 @@ final class DateFormat implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace([
-            'dateTime',
-            'dateOnly',
-            'timeOnly',
-            'dateTimeYear',
-            'dateYear',
-        ], [self::DATE_TIME, self::DATE_ONLY, self::TIME_ONLY, self::DATE_TIME_YEAR, self::DATE_YEAR], $value);
+        return match ($value) {
+            'dateTime' => self::DATE_TIME,
+            'dateOnly' => self::DATE_ONLY,
+            'timeOnly' => self::TIME_ONLY,
+            'dateTimeYear' => self::DATE_TIME_YEAR,
+            'dateYear' => self::DATE_YEAR,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/DoorsOpenLabel.php
+++ b/src/Google/Enumerators/DoorsOpenLabel.php
@@ -22,6 +22,10 @@ final class DoorsOpenLabel implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace(['doorsOpen', 'gatesOpen'], [self::DOORS_OPEN, self::GATES_OPEN], $value);
+        return match ($value) {
+            'doorsOpen' => self::DOORS_OPEN,
+            'gatesOpen' => self::GATES_OPEN,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/EventTicket/ConfirmationCodeLabel.php
+++ b/src/Google/Enumerators/EventTicket/ConfirmationCodeLabel.php
@@ -34,11 +34,12 @@ final class ConfirmationCodeLabel implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace(['confirmationCode', 'confirmationNumber', 'orderNumber', 'reservationNumber'], [
-            self::CONFIRMATION_CODE,
-            self::CONFIRMATION_NUMBER,
-            self::ORDER_NUMBER,
-            self::RESERVATION_NUMBER,
-        ], $value);
+        return match ($value) {
+            'confirmationCode' => self::CONFIRMATION_CODE,
+            'confirmationNumber' => self::CONFIRMATION_NUMBER,
+            'orderNumber' => self::ORDER_NUMBER,
+            'reservationNumber' => self::RESERVATION_NUMBER,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/EventTicket/GateLabel.php
+++ b/src/Google/Enumerators/EventTicket/GateLabel.php
@@ -25,6 +25,11 @@ final class GateLabel implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace(['gate', 'door', 'entrance'], [self::GATE, self::DOOR, self::ENTRANCE], $value);
+        return match ($value) {
+            'gate' => self::GATE,
+            'door' => self::DOOR,
+            'entrance' => self::ENTRANCE,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/EventTicket/RowLabel.php
+++ b/src/Google/Enumerators/EventTicket/RowLabel.php
@@ -19,6 +19,9 @@ final class RowLabel implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace(['row'], [self::ROW], $value);
+        return match ($value) {
+            'row' => self::ROW,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/EventTicket/SeatLabel.php
+++ b/src/Google/Enumerators/EventTicket/SeatLabel.php
@@ -19,6 +19,9 @@ final class SeatLabel implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace(['seat'], [self::SEAT], $value);
+        return match ($value) {
+            'seat' => self::SEAT,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/EventTicket/SectionLabel.php
+++ b/src/Google/Enumerators/EventTicket/SectionLabel.php
@@ -22,6 +22,10 @@ final class SectionLabel implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace(['section', 'theater'], [self::SECTION, self::THEATER], $value);
+        return match ($value) {
+            'section' => self::SECTION,
+            'theater' => self::THEATER,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/Flight/BoardingDoor.php
+++ b/src/Google/Enumerators/Flight/BoardingDoor.php
@@ -22,6 +22,10 @@ final class BoardingDoor implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace(['front', 'back'], [self::FRONT, self::BACK], $value);
+        return match ($value) {
+            'front' => self::FRONT,
+            'back' => self::BACK,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/Flight/BoardingPolicy.php
+++ b/src/Google/Enumerators/Flight/BoardingPolicy.php
@@ -30,10 +30,11 @@ final class BoardingPolicy implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace([
-            'zoneBased',
-            'groupBased',
-            'boardingPolicyOther',
-        ], [self::ZONE_BASED, self::GROUP_BASED, self::BOARDING_POLICY_OTHER], $value);
+        return match ($value) {
+            'zoneBased' => self::ZONE_BASED,
+            'groupBased' => self::GROUP_BASED,
+            'boardingPolicyOther' => self::BOARDING_POLICY_OTHER,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/Flight/FlightStatus.php
+++ b/src/Google/Enumerators/Flight/FlightStatus.php
@@ -42,13 +42,14 @@ final class FlightStatus implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace(['scheduled', 'active', 'landed', 'cancelled', 'redirected', 'diverted'], [
-            self::SCHEDULED,
-            self::ACTIVE,
-            self::LANDED,
-            self::CANCELLED,
-            self::REDIRECTED,
-            self::DIVERTED,
-        ], $value);
+        return match ($value) {
+            'scheduled' => self::SCHEDULED,
+            'active' => self::ACTIVE,
+            'landed' => self::LANDED,
+            'cancelled' => self::CANCELLED,
+            'redirected' => self::REDIRECTED,
+            'diverted' => self::DIVERTED,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/Flight/SeatClassPolicy.php
+++ b/src/Google/Enumerators/Flight/SeatClassPolicy.php
@@ -34,11 +34,12 @@ final class SeatClassPolicy implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace([
-            'cabinBased',
-            'classBased',
-            'tierBased',
-            'seatClassPolicyOther',
-        ], [self::CABIN_BASED, self::CLASS_BASED, self::TIER_BASED, self::SEAT_CLASS_POLICY_OTHER], $value);
+        return match ($value) {
+            'cabinBased' => self::CABIN_BASED,
+            'classBased' => self::CLASS_BASED,
+            'tierBased' => self::TIER_BASED,
+            'seatClassPolicyOther' => self::SEAT_CLASS_POLICY_OTHER,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/Loyalty/VisibilityState.php
+++ b/src/Google/Enumerators/Loyalty/VisibilityState.php
@@ -25,10 +25,11 @@ final class VisibilityState implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace([
-            'trustedTesters',
-            'live',
-            'disabled',
-        ], [self::TRUSTED_TESTERS, self::LIVE, self::DISABLED], $value);
+        return match ($value) {
+            'trustedTesters' => self::TRUSTED_TESTERS,
+            'live' => self::LIVE,
+            'disabled' => self::DISABLED,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/MessageType.php
+++ b/src/Google/Enumerators/MessageType.php
@@ -22,9 +22,10 @@ final class MessageType implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace([
-            'text',
-            'expirationNotification',
-        ], [self::TEXT, self::EXPIRATION_NOTIFICATION], $value);
+        return match ($value) {
+            'text' => self::TEXT,
+            'expirationNotification' => self::EXPIRATION_NOTIFICATION,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/MultipleDevicesAndHoldersAllowedStatus.php
+++ b/src/Google/Enumerators/MultipleDevicesAndHoldersAllowedStatus.php
@@ -30,10 +30,11 @@ final class MultipleDevicesAndHoldersAllowedStatus implements LegacyValueEnumera
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace([
-            'multipleHolders',
-            'oneUserAllDevices',
-            'oneUserOneDevice',
-        ], [self::MULTIPLE_HOLDERS, self::ONE_USER_ALL_DEVICES, self::ONE_USER_ONE_DEVICE], $value);
+        return match ($value) {
+            'multipleHolders' => self::MULTIPLE_HOLDERS,
+            'oneUserAllDevices' => self::ONE_USER_ALL_DEVICES,
+            'oneUserOneDevice' => self::ONE_USER_ONE_DEVICE,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/Offer/RedemptionChannel.php
+++ b/src/Google/Enumerators/Offer/RedemptionChannel.php
@@ -34,11 +34,12 @@ final class RedemptionChannel implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace([
-            'instore',
-            'online',
-            'both',
-            'temporaryPriceReduction',
-        ], [self::INSTORE, self::ONLINE, self::BOTH, self::TEMPORARY_PRICE_REDUCTION], $value);
+        return match ($value) {
+            'instore' => self::INSTORE,
+            'online' => self::ONLINE,
+            'both' => self::BOTH,
+            'temporaryPriceReduction' => self::TEMPORARY_PRICE_REDUCTION,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/PredefinedItem.php
+++ b/src/Google/Enumerators/PredefinedItem.php
@@ -26,9 +26,10 @@ final class PredefinedItem implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace(['frequentFlyerProgramNameAndNumber', 'flightNumberAndOperatingFlightNumber'], [
-            self::FREQUENT_FLYER_PROGRAM_NAME_AND_NUMBER,
-            self::FLIGHT_NUMBER_AND_OPERATING_FLIGHT_NUMBER,
-        ], $value);
+        return match ($value) {
+            'frequentFlyerProgramNameAndNumber' => self::FREQUENT_FLYER_PROGRAM_NAME_AND_NUMBER,
+            'flightNumberAndOperatingFlightNumber' => self::FLIGHT_NUMBER_AND_OPERATING_FLIGHT_NUMBER,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/ReviewStatus.php
+++ b/src/Google/Enumerators/ReviewStatus.php
@@ -28,11 +28,12 @@ final class ReviewStatus implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace([
-            'underReview',
-            'approved',
-            'rejected',
-            'draft',
-        ], [self::UNDER_REVIEW, self::APPROVED, self::REJECTED, self::DRAFT], $value);
+        return match ($value) {
+            'underReview' => self::UNDER_REVIEW,
+            'approved' => self::APPROVED,
+            'rejected' => self::REJECTED,
+            'draft' => self::DRAFT,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/State.php
+++ b/src/Google/Enumerators/State.php
@@ -28,11 +28,12 @@ final class State implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace([
-            'active',
-            'completed',
-            'expired',
-            'inactive',
-        ], [self::ACTIVE, self::COMPLETED, self::EXPIRED, self::INACTIVE], $value);
+        return match ($value) {
+            'active' => self::ACTIVE,
+            'completed' => self::COMPLETED,
+            'expired' => self::EXPIRED,
+            'inactive' => self::INACTIVE,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/Transit/ConcessionCategory.php
+++ b/src/Google/Enumerators/Transit/ConcessionCategory.php
@@ -25,6 +25,11 @@ final class ConcessionCategory implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace(['adult', 'child', 'senior'], [self::ADULT, self::CHILD, self::SENIOR], $value);
+        return match ($value) {
+            'adult' => self::ADULT,
+            'child' => self::CHILD,
+            'senior' => self::SENIOR,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/Transit/FareClass.php
+++ b/src/Google/Enumerators/Transit/FareClass.php
@@ -25,6 +25,11 @@ final class FareClass implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace(['economy', 'first', 'business'], [self::ECONOMY, self::FIRST, self::BUSINESS], $value);
+        return match ($value) {
+            'economy' => self::ECONOMY,
+            'first' => self::FIRST,
+            'business' => self::BUSINESS,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/Transit/PassengerType.php
+++ b/src/Google/Enumerators/Transit/PassengerType.php
@@ -22,9 +22,10 @@ final class PassengerType implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace([
-            'singlePassenger',
-            'multiplePassengers',
-        ], [self::SINGLE_PASSENGER, self::MULTIPLE_PASSENGERS], $value);
+        return match ($value) {
+            'singlePassenger' => self::SINGLE_PASSENGER,
+            'multiplePassengers' => self::MULTIPLE_PASSENGERS,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/Transit/TicketStatus.php
+++ b/src/Google/Enumerators/Transit/TicketStatus.php
@@ -25,10 +25,11 @@ final class TicketStatus implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace([
-            'used',
-            'refunded',
-            'exchanged',
-        ], [self::USED, self::REFUNDED, self::EXCHANGED], $value);
+        return match ($value) {
+            'used' => self::USED,
+            'refunded' => self::REFUNDED,
+            'exchanged' => self::EXCHANGED,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/Transit/TransitType.php
+++ b/src/Google/Enumerators/Transit/TransitType.php
@@ -31,12 +31,13 @@ final class TransitType implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace([
-            'bus',
-            'rail',
-            'tram',
-            'ferry',
-            'other',
-        ], [self::BUS, self::RAIL, self::TRAM, self::FERRY, self::OTHER], $value);
+        return match ($value) {
+            'bus' => self::BUS,
+            'rail' => self::RAIL,
+            'tram' => self::TRAM,
+            'ferry' => self::FERRY,
+            'other' => self::OTHER,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/Transit/TripType.php
+++ b/src/Google/Enumerators/Transit/TripType.php
@@ -22,6 +22,10 @@ final class TripType implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace(['roundTrip', 'oneWay'], [self::ROUND_TRIP, self::ONE_WAY], $value);
+        return match ($value) {
+            'roundTrip' => self::ROUND_TRIP,
+            'oneWay' => self::ONE_WAY,
+            default => $value,
+        };
     }
 }

--- a/src/Google/Enumerators/TransitOption.php
+++ b/src/Google/Enumerators/TransitOption.php
@@ -30,10 +30,11 @@ final class TransitOption implements LegacyValueEnumerator
 
     public function mapLegacyValues(string $value): string
     {
-        return str_replace([
-            'originAndDestinationNames',
-            'originAndDestinationCodes',
-            'originName',
-        ], [self::ORIGIN_AND_DESTINATION_NAMES, self::ORIGIN_AND_DESTINATION_CODES, self::ORIGIN_NAME], $value);
+        return match ($value) {
+            'originAndDestinationNames' => self::ORIGIN_AND_DESTINATION_NAMES,
+            'originAndDestinationCodes' => self::ORIGIN_AND_DESTINATION_CODES,
+            'originName' => self::ORIGIN_NAME,
+            default => $value,
+        };
     }
 }


### PR DESCRIPTION
Hi, thank you for making this package.

It looks like use of `str_replace` in the `mapLegacyValues()` method can lead to some values being partially substituted (e.g. "inACTIVE".)

To avoid this I have replaced these with PHP 8.0+ match expressions. They seem like a nice fit for this.

This change should fix the following issues:
- #28 
- https://github.com/chiiya/laravel-passes/issues/21