### PR TITLE
Update Google CardRowTemplateInfo count

### DIFF
--- a/src/Google/Components/Common/ClassTemplate/CardTemplateOverride.php
+++ b/src/Google/Components/Common/ClassTemplate/CardTemplateOverride.php
@@ -11,6 +11,11 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 class CardTemplateOverride extends Component
 {
     public function __construct(
+        /**
+         * Required.
+         * 
+         * @var CardRowTemplateInfo[]
+         */
         #[Cast(ArrayCaster::class, CardRowTemplateInfo::class)]
         #[NotBlank]
         #[Count(max: 3)]

--- a/src/Google/Components/Common/ClassTemplate/CardTemplateOverride.php
+++ b/src/Google/Components/Common/ClassTemplate/CardTemplateOverride.php
@@ -11,14 +11,9 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 class CardTemplateOverride extends Component
 {
     public function __construct(
-        /**
-         * Required.
-         *
-         * @var FieldReference[]
-         */
         #[Cast(ArrayCaster::class, CardRowTemplateInfo::class)]
         #[NotBlank]
-        #[Count(max: 2)]
+        #[Count(max: 3)]
         public array $cardRowTemplateInfos = [],
     ) {
         parent::__construct();


### PR DESCRIPTION
I updated the number of elements in the cardRowTemplateInfos array. According to Google’s official documentation, cardRowTemplateInfos can contain up to three elements, not two.   Google docs: https://developers.google.com/wallet/reference/rest/v1/ClassTemplateInfo#CardTemplateOverride

Additionally, the field was incorrectly typed as an array of FieldReference.