### PR TITLE
Fix date decoding for RFC3339 timestamps from Google API

### DIFF
--- a/src/Common/Casters/DateCaster.php
+++ b/src/Common/Casters/DateCaster.php
@@ -5,22 +5,28 @@ namespace Chiiya\Passes\Common\Casters;
 use Antwerpes\DataTransferObject\CastsProperty;
 use DateTimeImmutable;
 use DateTimeInterface;
+use Exception;
 
 abstract class DateCaster implements CastsProperty
 {
     public function unserialize(mixed $value): ?DateTimeImmutable
     {
-        if ($value === null) {
+        if ($value instanceof DateTimeImmutable) {
+            return $value;
+        }
+
+        if (! is_string($value) || $value === '') {
             return null;
         }
 
-        $date = DateTimeImmutable::createFromFormat($this->format(), $value);
-
-        if ($date === false) {
+        // Parse permissively: the Google Wallet API returns RFC3339 timestamps with
+        // fractional seconds and a 'Z' suffix (e.g. 2023-01-01T12:00:00.000Z) that a
+        // strict createFromFormat() against ATOM/W3C cannot match.
+        try {
+            return new DateTimeImmutable($value);
+        } catch (Exception) {
             return null;
         }
-
-        return $date;
     }
 
     public function serialize(mixed $value): ?string

--- a/tests/Common/Casters/DateCasterTest.php
+++ b/tests/Common/Casters/DateCasterTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Chiiya\Passes\Tests\Common\Casters;
+
+use Chiiya\Passes\Common\Casters\ISO8601DateCaster;
+use Chiiya\Passes\Tests\TestCase;
+use DateTimeImmutable;
+use DateTimeInterface;
+use PHPUnit\Framework\Attributes\Group;
+
+class DateCasterTest extends TestCase
+{
+    #[Group('common')]
+    public function test_parses_rfc3339_with_fractional_seconds_and_zulu(): void
+    {
+        // Regression for #42: the Google Wallet API returns timestamps in this form.
+        $date = (new ISO8601DateCaster([]))->unserialize('2023-01-01T12:00:00.000Z');
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $date);
+        $this->assertSame('2023-01-01T12:00:00+00:00', $date->format(DateTimeInterface::ATOM));
+    }
+
+    #[Group('common')]
+    public function test_parses_zulu_and_offset_timestamps(): void
+    {
+        $caster = new ISO8601DateCaster([]);
+
+        $this->assertSame(
+            '2023-01-01T12:00:00+00:00',
+            $caster->unserialize('2023-01-01T12:00:00Z')?->format(DateTimeInterface::ATOM),
+        );
+        $this->assertSame(
+            '2020-12-21T00:00:00+01:00',
+            $caster->unserialize('2020-12-21T00:00:00+01:00')?->format(DateTimeInterface::ATOM),
+        );
+    }
+
+    #[Group('common')]
+    public function test_returns_null_for_empty_or_unparseable_values(): void
+    {
+        $caster = new ISO8601DateCaster([]);
+
+        $this->assertNull($caster->unserialize(null));
+        $this->assertNull($caster->unserialize(''));
+        $this->assertNull($caster->unserialize('not-a-date'));
+    }
+
+    #[Group('common')]
+    public function test_returns_existing_immutable_instance_as_is(): void
+    {
+        $value = new DateTimeImmutable('2023-01-01T12:00:00+00:00');
+
+        $this->assertSame($value, (new ISO8601DateCaster([]))->unserialize($value));
+    }
+}


### PR DESCRIPTION
## Problem

Fixes [laravel-passes#42](https://github.com/chiiya/laravel-passes/issues/42).

Fetching or updating a Google Wallet object (`get`/`create`/`update` in `BaseRepository`) throws:

```
DateTime::__construct(): Argument #1 ($date) must be of type DateTimeInterface|string, null given
```

## Root cause

The Google Wallet API returns RFC3339 timestamps with fractional seconds and a `Z` suffix (e.g. `2023-01-01T12:00:00.000Z`). `DateCaster::unserialize()` parsed with the strict `DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $value)`. `ATOM` (`Y-m-d\TH:i:sP`) cannot match the `.000Z` form, so `createFromFormat` returned `false` and the caster returned `null`. That `null` was then passed to the non-nullable `DateTime::$date` constructor parameter during `decode()`, raising the `TypeError`.

## Fix

Parse permissively via the `DateTimeImmutable` constructor, which handles `ATOM`, `W3C`, fractional seconds, and `Z`/offset suffixes uniformly. `serialize()` and `format()` are unchanged, so outgoing serialization (and the round-trip tests) stay the same. Non-string / empty / unparseable input is normalized to `null`.

Holding fields are already nullable (`?DateTime $start/$end`, `?DateTime $balanceUpdateTime`), so a `null` from the API is short-circuited by `DTOCaster` and never reaches the constructor — no need to change `DateTime::$date` itself.

## Tests

Added `tests/Common/Casters/DateCasterTest.php` covering:
- `2023-01-01T12:00:00.000Z` parses correctly
- `Z` and offset timestamps parse correctly
- `null`, empty string, and unparseable input return `null`
- an existing `DateTimeImmutable` is returned as-is

Full suite passes (51 tests); `just lint` clean.