### PR TITLE
Fix EventDateTime cast failing on date properties

### DIFF
--- a/src/Google/Components/EventTicket/EventDateTime.php
+++ b/src/Google/Components/EventTicket/EventDateTime.php
@@ -8,6 +8,7 @@ use Chiiya\Passes\Common\Casters\LegacyValueCaster;
 use Chiiya\Passes\Common\Component;
 use Chiiya\Passes\Google\Components\Common\LocalizedString;
 use Chiiya\Passes\Google\Enumerators\DoorsOpenLabel;
+use DateTimeInterface;
 use Symfony\Component\Validator\Constraints\Choice;
 
 class EventDateTime extends Component
@@ -19,21 +20,21 @@ class EventDateTime extends Component
          * ISO 8601 + optional offset.
          */
         #[Cast(ISO8601DateCaster::class)]
-        public ?string $doorsOpen = null,
+        public DateTimeInterface|string|null $doorsOpen = null,
         /**
          * Optional.
          * The date/time when the event starts.
          * ISO 8601 + optional offset.
          */
         #[Cast(ISO8601DateCaster::class)]
-        public ?string $start = null,
+        public DateTimeInterface|string|null $start = null,
         /**
          * Optional.
          * The date/time when the event ends.
          * ISO 8601 + optional offset.
          */
         #[Cast(ISO8601DateCaster::class)]
-        public ?string $end = null,
+        public DateTimeInterface|string|null $end = null,
         /**
          * Optional.
          * The label to use for the doors open value (doorsOpen) on the card detail view.

--- a/tests/Google/Components/EventTicket/EventDateTimeTest.php
+++ b/tests/Google/Components/EventTicket/EventDateTimeTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Chiiya\Passes\Tests\Google\Components\EventTicket;
+
+use Chiiya\Passes\Google\Components\EventTicket\EventDateTime;
+use Chiiya\Passes\Tests\TestCase;
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Group;
+
+class EventDateTimeTest extends TestCase
+{
+    #[Group('google')]
+    public function test_decodes_iso8601_date_strings_into_dates(): void
+    {
+        // Regression for #41: the ISO8601DateCaster returns a DateTimeImmutable, which
+        // could not be assigned to the previously ?string-typed properties.
+        $component = EventDateTime::decode([
+            'doorsOpen' => '2023-01-01T12:00:00+00:00',
+            'start' => '2023-01-01T13:00:00+00:00',
+            'end' => '2023-01-01T15:00:00+00:00',
+        ]);
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $component->doorsOpen);
+        $this->assertInstanceOf(DateTimeImmutable::class, $component->start);
+        $this->assertInstanceOf(DateTimeImmutable::class, $component->end);
+    }
+
+    #[Group('google')]
+    public function test_serializes_dates_back_to_iso8601_strings(): void
+    {
+        $attributes = [
+            'doorsOpen' => '2023-01-01T12:00:00+00:00',
+            'start' => '2023-01-01T13:00:00+00:00',
+            'end' => '2023-01-01T15:00:00+00:00',
+        ];
+
+        $this->assertSameArray($attributes, EventDateTime::decode($attributes)->jsonSerialize());
+    }
+
+    #[Group('google')]
+    public function test_accepts_plain_date_strings_on_construction(): void
+    {
+        $component = new EventDateTime(start: '2023-01-01T13:00:00+00:00');
+
+        $this->assertSame('2023-01-01T13:00:00+00:00', $component->encode()['start']);
+    }
+}


### PR DESCRIPTION
## Problem

Fixes chiiya/laravel-passes#41.

Adding a `dateTime` (`EventDateTime`) to an `EventTicketClass` and decoding it throws:

```
EventDateTime::__construct(): Argument #1 ($doorsOpen) must be of type ?string, DateTimeImmutable given
```

## Root cause

In `Google\Components\EventTicket\EventDateTime`, the `doorsOpen`, `start` and `end` properties carry `#[Cast(ISO8601DateCaster::class)]`, but were typed `?string`. `DateCaster::unserialize()` returns a `DateTimeImmutable`, which cannot be assigned to a `?string` parameter during `decode()` — hence the `TypeError`.

This is the inverse of the issue fixed in #51: there the caster returned `null` into a non-nullable param; here it returns a `DateTimeImmutable` into a `string` param.

## Fix

Type the three date properties `DateTimeInterface|string|null`, matching `Common\DateTime::$date`. The cast result now fits, and `DateCaster::serialize()` already handles both `DateTimeInterface` and string inputs, so building/encoding is unaffected (round-trip still emits canonical ISO8601 strings).

## Tests

Added `tests/Google/Components/EventTicket/EventDateTimeTest.php`:
- decoding ISO8601 strings yields `DateTimeImmutable` values
- round-trip decode → serialize emits canonical ISO8601 strings
- constructing with plain date strings still works

Full suite passes (54 tests); `just lint` clean.