### PR TITLE
Add missing TEXT_AND_NOTIFY message type

### DIFF
--- a/src/Google/Components/Common/Message.php
+++ b/src/Google/Components/Common/Message.php
@@ -39,6 +39,7 @@ class Message extends Component
             MessageType::EXPIRATION_NOTIFICATION,
             MessageType::MESSAGE_TYPE_UNSPECIFIED,
             MessageType::TEXT,
+            MessageType::TEXT_AND_NOTIFY,
         ])]
         #[Cast(LegacyValueCaster::class, MessageType::class)]
         public ?string $messageType = null,

--- a/src/Google/Enumerators/MessageType.php
+++ b/src/Google/Enumerators/MessageType.php
@@ -13,11 +13,14 @@ final class MessageType implements LegacyValueEnumerator
     public const TEXT = 'TEXT';
 
     /** @var string */
+    public const TEXT_AND_NOTIFY = 'TEXT_AND_NOTIFY';
+
+    /** @var string */
     public const EXPIRATION_NOTIFICATION = 'EXPIRATION_NOTIFICATION';
 
     public static function values(): array
     {
-        return [self::MESSAGE_TYPE_UNSPECIFIED, self::TEXT, self::EXPIRATION_NOTIFICATION];
+        return [self::MESSAGE_TYPE_UNSPECIFIED, self::TEXT, self::TEXT_AND_NOTIFY, self::EXPIRATION_NOTIFICATION];
     }
 
     public static function mapLegacyValues(string $value): string


### PR DESCRIPTION
## Problem

Fixes chiiya/laravel-passes#43.

`TEXT_AND_NOTIFY` is a valid Google Wallet [`MessageType`](https://developers.google.com/wallet/reference/rest/v1/Message#MessageType) but was missing from `Google\Enumerators\MessageType`. As a result the `Message` component's `#[Choice]` validation rejected it.

## Fix

- Add the `TEXT_AND_NOTIFY` constant to `MessageType` and include it in `values()`.
- Add it to the allowed `#[Choice]` choices on `Message::$messageType`.

`mapLegacyValues()` needs no change — `TEXT_AND_NOTIFY` has no legacy camelCase form, so the existing `default => $value` passthrough handles it.