### PR TITLE
Skip validation when decoding API responses

### DIFF
--- a/src/Common/Component.php
+++ b/src/Common/Component.php
@@ -9,8 +9,19 @@ use Symfony\Component\Validator\Validation;
 
 abstract class Component extends DataTransferObject implements JsonSerializable
 {
+    /**
+     * Whether constructed components should be validated. Disabled while decoding API
+     * responses, since responses may legitimately omit fields that are only required
+     * when creating a pass. Validation still runs for objects constructed directly.
+     */
+    private static bool $validate = true;
+
     public function __construct()
     {
+        if (! self::$validate) {
+            return;
+        }
+
         $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
         $errors = $validator->validate($this);
 
@@ -22,6 +33,18 @@ abstract class Component extends DataTransferObject implements JsonSerializable
             }
 
             throw new ValidationException('Invalid arguments', $messages);
+        }
+    }
+
+    public static function decode(array $data): static
+    {
+        $previous = self::$validate;
+        self::$validate = false;
+
+        try {
+            return parent::decode($data);
+        } finally {
+            self::$validate = $previous;
         }
     }
 

--- a/tests/Common/ComponentTest.php
+++ b/tests/Common/ComponentTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Chiiya\Passes\Tests\Common;
+
+use Chiiya\Passes\Exceptions\ValidationException;
+use Chiiya\Passes\Google\Components\Common\Message;
+use Chiiya\Passes\Google\Passes\LoyaltyObject;
+use Chiiya\Passes\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+class ComponentTest extends TestCase
+{
+    #[Group('common')]
+    public function test_decode_does_not_run_validation(): void
+    {
+        // The API may return values our constraints don't expect; decoding a response
+        // must never fail validation (see chiiya/laravel-passes#40).
+        $message = Message::decode(['messageType' => 'SOME_FUTURE_TYPE']);
+
+        $this->assertSame('SOME_FUTURE_TYPE', $message->messageType);
+    }
+
+    #[Group('common')]
+    public function test_direct_construction_still_runs_validation(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        new Message(messageType: 'SOME_FUTURE_TYPE');
+    }
+
+    #[Group('google')]
+    public function test_decode_skips_validation_for_nested_components(): void
+    {
+        // Regression for chiiya/laravel-passes#40: updating a loyalty pass decodes the
+        // response, whose classReference may carry values/fields our validation rejects.
+        $object = LoyaltyObject::decode([
+            'id' => 'issuer.object',
+            'classId' => 'issuer.class',
+            'state' => 'ACTIVE',
+            'classReference' => [
+                'id' => 'issuer.class',
+                'reviewStatus' => 'SOME_FUTURE_STATUS',
+                'programLogo' => ['sourceUri' => ['uri' => 'https://example.com/logo.png']],
+            ],
+        ]);
+
+        $this->assertSame('SOME_FUTURE_STATUS', $object->classReference->reviewStatus);
+        $this->assertNull($object->classReference->issuerName);
+    }
+}


### PR DESCRIPTION
## Problem

Fixes chiiya/laravel-passes#40.

Updating (or fetching) a pass decodes the API response back into component objects via `BaseRepository`. `Component::__construct()` runs Symfony validation on **every** construction — including during `decode()` — so a response that legitimately omits fields only required *when creating* a pass throws spurious validation errors:

```
Validation errors:
  - Chiiya\Passes\Google\Passes\LoyaltyClass->programName: The field is required.
  - Chiiya\Passes\Google\Passes\LoyaltyClass->issuerName: The field is required.
```

The reporter correctly traced it to `BaseRepository::update()`, which builds a `LoyaltyObject` from the response whose `classReference` is partial.

## Root cause

Requiredness/validity is a **send-time** concern, but it was being enforced at **parse-time**. We don't control what Google returns, so decoding must be lenient.

## Fix

Skip validation while decoding. `Component::decode()` toggles a guard that makes `__construct()` bypass validation, and restores the previous value in a `finally` (so nested decoding — e.g. `classReference` inside an object — is handled correctly). Validation still runs for objects you construct directly to send, so invalid outgoing data is still caught.

This resolves the whole class of "validation failed while decoding a response" bugs, not just the loyalty case.

### Scope note

A response can also fail to decode if it omits a field whose property is **non-nullable** (e.g. `LoyaltyClass::$programLogo`), which would throw a `TypeError` rather than a validation error. In practice a real `classReference` includes the class's genuinely-required fields, so this isn't hit by #40. Making every decodable required field nullable would touch ~60 fields across ~38 files and is intentionally left out of this PR.

## Tests

Added `tests/Common/ComponentTest.php`:
- decoding a response with an unexpected constraint value does **not** throw
- constructing the same object directly **still** throws `ValidationException`
- decoding a `LoyaltyObject` with a nested partial `classReference` (the #40 path) succeeds

Full suite passes (57 tests); `just lint` clean.